### PR TITLE
fix: raise custom exceptions

### DIFF
--- a/anipie/__init__.py
+++ b/anipie/__init__.py
@@ -2,3 +2,8 @@
 # from .searchManga import SearchManga
 
 from .search_by_query import SearchByQuery
+from .exceptions import TitleNotFoundError
+
+# Explicity export these when someone uses
+# from anipie import *
+__all__ = ["SearchByQuery", "TitleNotFoundError"]

--- a/anipie/__init__.py
+++ b/anipie/__init__.py
@@ -2,8 +2,18 @@
 # from .searchManga import SearchManga
 
 from .search_by_query import SearchByQuery
-from .exceptions import TitleNotFoundError
+from . import exceptions
+from .exceptions import QueryTypeError, TitleNotFoundError
 
 # Explicity export these when someone uses
 # from anipie import *
-__all__ = ["SearchByQuery", "TitleNotFoundError"]
+__all__ = [
+    "SearchByQuery",
+    # exporting the module so the exceptions can be accessed as such:
+    # from anipie.exceptions import TitleNotFoundError
+    "exceptions",
+    # Exporting the exceptions individually so they are also available as:
+    # from anipie import TitleNotFoundError
+    "QueryTypeError",
+    "TitleNotFoundError",
+]

--- a/anipie/exceptions.py
+++ b/anipie/exceptions.py
@@ -1,0 +1,9 @@
+class AnipieException(Exception):
+    """Base exception for all Anipie errors"""
+    
+    pass
+
+class TitleNotFoundError(AnipieException):
+    """Requested title was not found"""
+
+    pass

--- a/anipie/exceptions.py
+++ b/anipie/exceptions.py
@@ -6,4 +6,13 @@ class AnipieException(Exception):
 class TitleNotFoundError(AnipieException):
     """Requested title was not found"""
 
-    pass
+    def __init__(self, message: str, /, *, title: str) -> None:
+        super().__init__(message)
+        self.title = title
+
+class QueryTypeError(AnipieException):
+    """Invalid query type"""
+
+    def __init__(self, message: str, /, *, type: str) -> None:
+        super().__init__(message)
+        self.type = type

--- a/anipie/search_by_query.py
+++ b/anipie/search_by_query.py
@@ -1,6 +1,6 @@
 import re
 import requests
-from anipie.exceptions import TitleNotFoundError
+from anipie.exceptions import QueryTypeError, TitleNotFoundError
 from anipie.queries import ANIME_QUERY, MANGA_QUERY, ANIME_API_URL
 
 
@@ -16,7 +16,7 @@ class SearchByQuery:
         elif self._type.upper() == "MANGA":
             self._type = "MANGA"
         else:
-            raise ValueError("Type must be either 'ANIME' or 'MANGA'")
+            raise QueryTypeError("Type must be either 'ANIME' or 'MANGA'", type=self._type)
         self._search()
 
     def _search(self) -> None:
@@ -34,7 +34,7 @@ class SearchByQuery:
             self._response = response.json()
             self._media = self._response.get("data").get("Media")
         except requests.exceptions.RequestException:
-            raise TitleNotFoundError(f"{self._title} was not found in Anilist")
+            raise TitleNotFoundError(f"{self._title} was not found in Anilist", title=self._title)
 
     def get_raw_data(self) -> dict:
         """Returns the raw JSON data from the API."""

--- a/anipie/search_by_query.py
+++ b/anipie/search_by_query.py
@@ -1,5 +1,6 @@
 import re
 import requests
+from anipie.exceptions import TitleNotFoundError
 from anipie.queries import ANIME_QUERY, MANGA_QUERY, ANIME_API_URL
 
 
@@ -32,8 +33,8 @@ class SearchByQuery:
             response.raise_for_status()
             self._response = response.json()
             self._media = self._response.get("data").get("Media")
-        except requests.exceptions.RequestException as e:
-            return e
+        except requests.exceptions.RequestException:
+            raise TitleNotFoundError(f"{self._title} was not found in Anilist")
 
     def get_raw_data(self) -> dict:
         """Returns the raw JSON data from the API."""


### PR DESCRIPTION
Custom exception for ease of use.

```py
>>> from anipie import SearchByQuery
>>> from anipie.exceptions import TitleNotFoundError, QueryTypeError
>>> try:
...     anime = SearchByQuery("nonexistent title")
...     print(anime.get_english_name)
... except TitleNotFoundError as error:
...     print(f"{error.title} not found")
nonexistent title not found
```

```py
>>> from anipie import SearchByQuery, TitleNotFoundError, QueryTypeError
>>> try:
...     anime = SearchByQuery("nonexistent title", type="some")
...     print(anime.get_english_name)
... except QueryTypeError  as error:
...     print(f"{error.type} not found")
some not found
```

Closes #1 